### PR TITLE
Sessions bugfix

### DIFF
--- a/pawprint/statistics.py
+++ b/pawprint/statistics.py
@@ -127,7 +127,7 @@ class Statistics(object):
         ).to_sql(stats.table, stats.db, if_exists="append", index=False)
 
         # Write event/session lookup table to the database
-        event_session_map_data = event_session_map_data.rename(columns={"id": "event_id"})
+        event_session_map_data = event_session_map_data.rename(columns={event_id_col: "event_id"})
         event_session_map_data[
             ["event_id", "user_id", "timestamp", "session_timestamp"]
         ].sort_values("session_timestamp").to_sql(

--- a/pawprint/statistics.py
+++ b/pawprint/statistics.py
@@ -21,7 +21,7 @@ class Statistics(object):
 
         return Tracker(db=self.tracker.db, table="{}__{}".format(self.tracker.table, tracker))
 
-    def sessions(self, duration=30, clean=False):
+    def sessions(self, duration=30, clean=False, event_id_col="id"):
         """Create a table of user sessions."""
 
         # Create a tracker for basic interaction
@@ -59,8 +59,8 @@ class Statistics(object):
             return
 
         # Query : the timestamp and user for all events since the last recorded session start
-        query = "SELECT id, {}, {} FROM {}".format(
-            self.tracker.user_field, self.tracker.timestamp_field, self.tracker.table
+        query = "SELECT {}, {}, {} FROM {}".format(
+            event_id_col, self.tracker.user_field, self.tracker.timestamp_field, self.tracker.table
         )
         if last_entry:
             query += " WHERE {} > %(last_entry)s".format(self.tracker.timestamp_field)

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -27,7 +27,7 @@ def test_sessions(pawprint_default_statistics_tracker):
     assert np.all(sessions.total_events == events)
 
     stats.sessions(clean=False)
-    assert len(stats["sessions"].read()) == 5
+    assert len(stats["sessions"].read()) == 4
 
     # Test that calculating sessions with no new data doesn't error
     stats.sessions()


### PR DESCRIPTION
This fixes a bug where events that were part of the last session were counted as part of a new session if you re-ran `Statistics.sessions(clean=False)`.

It also adds a series of tests to test for this and related bugs.