### PR TITLE
Batch events

### DIFF
--- a/pawprint/sessions.py
+++ b/pawprint/sessions.py
@@ -75,8 +75,11 @@ class Sessions:
     def close_open_sessions(self):
         for open_session in self.current_sessions.values():
             self.closed_sessions.append(open_session.close_session())
+        self.current_sessions = {}
 
     def write_to_db(self, table, db, if_exists="append", index=False):
         sessions_df = pd.DataFrame.from_records(self.closed_sessions)
-        sessions_df = sessions_df.sort_values("last_timestamp", ascending=True)
-        sessions_df.to_sql(table, db, if_exists=if_exists, index=index)
+        if sessions_df.shape[0] > 0:
+            sessions_df = sessions_df.sort_values("last_timestamp", ascending=True)
+            sessions_df.to_sql(table, db, if_exists=if_exists, index=index)
+        self.closed_sessions = []

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pawprint",
-    version="1.2.0",
+    version="2.0.0",
     description="A flexible event tracker for rapid analysis.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -27,6 +27,29 @@ def test_sessions(pawprint_default_statistics_tracker):
     assert np.all(sessions.total_events == events)
 
 
+def test_sessions_in_batches(pawprint_default_statistics_tracker):
+    """Test the calculation of session durations."""
+
+    tracker = pawprint_default_statistics_tracker
+    stats = pawprint.Statistics(tracker)
+
+    # Calculate user session durations
+    stats.sessions(batch_size=2)
+
+    # Read the results
+    sessions = stats["sessions"].read()
+
+    # Expected values
+    users = np.array(["Frodo", "Gandalf", "Frodo", "Frodo"])
+    durations = np.array([5, 40, 0, 4])
+    events = np.array([6, 4, 1, 5])
+
+    print(sessions.total_events)
+    assert np.all(sessions[tracker.user_field] == users)
+    assert np.all(sessions.duration == durations)
+    assert np.all(sessions.total_events == events)
+
+
 def test_sessions_with_no_new_data(pawprint_default_statistics_tracker):
     """Test that no new sessions created with no new data"""
     tracker = pawprint_default_statistics_tracker
@@ -132,94 +155,134 @@ def test_sessions_clean_equals_true_resets(pawprint_default_statistics_tracker):
     assert len(stats["sessions"].read()) == 7
 
 
-def test_engagement_metrics(pawprint_default_statistics_tracker):
-    """Test the calculation of user engagement metrics."""
-
+def test_sessions_with_new_data_in_batches(pawprint_default_statistics_tracker):
+    """Test that the correct number of new sessions are created with new data"""
     tracker = pawprint_default_statistics_tracker
     stats = pawprint.Statistics(tracker)
 
-    # Calculate user engagement
-    stats.sessions()
-    stats.engagement(min_sessions=0)
+    # Calculate user session durations
+    stats.sessions(batch_size=2)
 
     # Read the results
-    stickiness = stats["engagement"].read()
+    sessions = stats["sessions"].read()
+
+    # New data
+    new_users = ["Frodo", "Sam", "Sauron", "Bilbo", "Bilbo", "Bilbo"]
+    new_timedeltas = [1005, 2000, 2010, 2100, 2101, 2102]
+    new_events = ["wanted", "helped", "looked", "joined", "fought", "wrote"]
+
+    # Yesterday morning
+    today = datetime.now()
+    yesterday = datetime(today.year, today.month, today.day, 9, 0) - timedelta(days=1)
+
+    # Write all events
+    for user, delta, event in zip(new_users, new_timedeltas, new_events):
+        tracker.write(user_id=user, timestamp=yesterday + timedelta(minutes=delta), event=event)
 
     # Expected values
-    dau = np.array([2, 1])
-    wau = np.array([2, 2])
-    mau = np.array([2, 2])
-    engagement = np.array([1, 0.5])
+    users = np.array(["Frodo", "Gandalf", "Frodo", "Frodo", "Sam", "Sauron", "Bilbo"])
+    durations = np.array([5, 40, 0, 5, 0, 0, 2])
+    events = np.array([6, 4, 1, 6, 1, 1, 3])
 
-    assert np.all(stickiness.dau == dau)
-    assert np.all(stickiness.wau == wau)
-    assert np.all(stickiness.mau == mau)
-    assert np.all(stickiness.engagement == engagement)
-    assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
+    # calculate sessions again with new data
+    stats.sessions(clean=False, batch_size=2)
+    sessions = stats["sessions"].read()
 
-
-def test_engagement_min_sessions(pawprint_default_statistics_tracker):
-
-    tracker = pawprint_default_statistics_tracker
-    stats = pawprint.Statistics(tracker)
-    stats.sessions()
-
-    # Now test with a minimum number of sessions
-    stats.engagement(min_sessions=2)
-    stickiness = stats["engagement"].read()
-
-    # Ground truth
-    active = np.array([1, 1])
-    engagement_active = np.array([1, 1])
-    dau = np.array([2, 1])
-
-    assert np.all(stickiness.dau_active == active)
-    assert np.all(stickiness.wau_active == active)
-    assert np.all(stickiness.mau_active == active)
-    assert np.all(stickiness.dau == dau)
-    assert np.all(stickiness.engagement_active == engagement_active)
-    assert set(stickiness.columns) == {
-        "timestamp",
-        "dau",
-        "wau",
-        "mau",
-        "engagement",
-        "dau_active",
-        "wau_active",
-        "mau_active",
-        "engagement_active",
-    }
-
-    # Test that running engagements again doesn't error if there's no new data
-    stats.engagement()
+    print(sessions)
+    assert np.all(sessions[tracker.user_field] == users)
+    assert np.all(sessions.duration == durations)
+    assert np.all(sessions.total_events == events)
+    assert len(stats["sessions"].read()) == 7
 
 
-def test_engagement_too_many_min_sessions(pawprint_default_statistics_tracker):
-    tracker = pawprint_default_statistics_tracker
-    stats = pawprint.Statistics(tracker)
-    stats.sessions()
+# def test_engagement_metrics(pawprint_default_statistics_tracker):
+#     """Test the calculation of user engagement metrics."""
 
-    # Test with too large a minimum sessions parameter
-    stats.engagement(min_sessions=20)
-    stickiness = stats["engagement"].read()
-    assert len(stickiness) == 2
-    assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
+#     tracker = pawprint_default_statistics_tracker
+#     stats = pawprint.Statistics(tracker)
+
+#     # Calculate user engagement
+#     stats.sessions()
+#     stats.engagement(min_sessions=0)
+
+#     # Read the results
+#     stickiness = stats["engagement"].read()
+
+#     # Expected values
+#     dau = np.array([2, 1])
+#     wau = np.array([2, 2])
+#     mau = np.array([2, 2])
+#     engagement = np.array([1, 0.5])
+
+#     assert np.all(stickiness.dau == dau)
+#     assert np.all(stickiness.wau == wau)
+#     assert np.all(stickiness.mau == mau)
+#     assert np.all(stickiness.engagement == engagement)
+#     assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
 
 
-def test_engagement_append_mode(pawprint_default_statistics_tracker):
-    tracker = pawprint_default_statistics_tracker
-    stats = pawprint.Statistics(tracker)
-    stats.sessions()
+# def test_engagement_min_sessions(pawprint_default_statistics_tracker):
 
-    stats.engagement(min_sessions=20)
+#     tracker = pawprint_default_statistics_tracker
+#     stats = pawprint.Statistics(tracker)
+#     stats.sessions()
 
-    # Try again with append-only
-    stats.engagement(clean=False)
-    stickiness = stats["engagement"].read()
-    assert len(stickiness.columns) == 5
-    assert len(stickiness) == 2
+#     # Now test with a minimum number of sessions
+#     stats.engagement(min_sessions=2)
+#     stickiness = stats["engagement"].read()
 
-    stats.engagement(clean=True, min_sessions=2)
-    stickiness = stats["engagement"].read()
-    assert len(stickiness) == 2
-    assert len(stickiness.columns) == 9
+#     # Ground truth
+#     active = np.array([1, 1])
+#     engagement_active = np.array([1, 1])
+#     dau = np.array([2, 1])
+
+#     assert np.all(stickiness.dau_active == active)
+#     assert np.all(stickiness.wau_active == active)
+#     assert np.all(stickiness.mau_active == active)
+#     assert np.all(stickiness.dau == dau)
+#     assert np.all(stickiness.engagement_active == engagement_active)
+#     assert set(stickiness.columns) == {
+#         "timestamp",
+#         "dau",
+#         "wau",
+#         "mau",
+#         "engagement",
+#         "dau_active",
+#         "wau_active",
+#         "mau_active",
+#         "engagement_active",
+#     }
+
+#     # Test that running engagements again doesn't error if there's no new data
+#     stats.engagement()
+
+
+# def test_engagement_too_many_min_sessions(pawprint_default_statistics_tracker):
+#     tracker = pawprint_default_statistics_tracker
+#     stats = pawprint.Statistics(tracker)
+#     stats.sessions()
+
+#     # Test with too large a minimum sessions parameter
+#     stats.engagement(min_sessions=20)
+#     stickiness = stats["engagement"].read()
+#     assert len(stickiness) == 2
+#     assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
+
+
+# def test_engagement_append_mode(pawprint_default_statistics_tracker):
+#     tracker = pawprint_default_statistics_tracker
+#     stats = pawprint.Statistics(tracker)
+#     stats.sessions()
+
+#     stats.engagement(min_sessions=20)
+
+#     # Try again with append-only
+#     stats.engagement(clean=False)
+#     stickiness = stats["engagement"].read()
+#     assert len(stickiness.columns) == 5
+#     assert len(stickiness) == 2
+
+#     stats.engagement(clean=True, min_sessions=2)
+#     stickiness = stats["engagement"].read()
+#     assert len(stickiness) == 2
+#     assert len(stickiness.columns) == 9

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -195,94 +195,94 @@ def test_sessions_with_new_data_in_batches(pawprint_default_statistics_tracker):
     assert len(stats["sessions"].read()) == 7
 
 
-# def test_engagement_metrics(pawprint_default_statistics_tracker):
-#     """Test the calculation of user engagement metrics."""
+def test_engagement_metrics(pawprint_default_statistics_tracker):
+    """Test the calculation of user engagement metrics."""
 
-#     tracker = pawprint_default_statistics_tracker
-#     stats = pawprint.Statistics(tracker)
+    tracker = pawprint_default_statistics_tracker
+    stats = pawprint.Statistics(tracker)
 
-#     # Calculate user engagement
-#     stats.sessions()
-#     stats.engagement(min_sessions=0)
+    # Calculate user engagement
+    stats.sessions()
+    stats.engagement(min_sessions=0)
 
-#     # Read the results
-#     stickiness = stats["engagement"].read()
+    # Read the results
+    stickiness = stats["engagement"].read()
 
-#     # Expected values
-#     dau = np.array([2, 1])
-#     wau = np.array([2, 2])
-#     mau = np.array([2, 2])
-#     engagement = np.array([1, 0.5])
+    # Expected values
+    dau = np.array([2, 1])
+    wau = np.array([2, 2])
+    mau = np.array([2, 2])
+    engagement = np.array([1, 0.5])
 
-#     assert np.all(stickiness.dau == dau)
-#     assert np.all(stickiness.wau == wau)
-#     assert np.all(stickiness.mau == mau)
-#     assert np.all(stickiness.engagement == engagement)
-#     assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
-
-
-# def test_engagement_min_sessions(pawprint_default_statistics_tracker):
-
-#     tracker = pawprint_default_statistics_tracker
-#     stats = pawprint.Statistics(tracker)
-#     stats.sessions()
-
-#     # Now test with a minimum number of sessions
-#     stats.engagement(min_sessions=2)
-#     stickiness = stats["engagement"].read()
-
-#     # Ground truth
-#     active = np.array([1, 1])
-#     engagement_active = np.array([1, 1])
-#     dau = np.array([2, 1])
-
-#     assert np.all(stickiness.dau_active == active)
-#     assert np.all(stickiness.wau_active == active)
-#     assert np.all(stickiness.mau_active == active)
-#     assert np.all(stickiness.dau == dau)
-#     assert np.all(stickiness.engagement_active == engagement_active)
-#     assert set(stickiness.columns) == {
-#         "timestamp",
-#         "dau",
-#         "wau",
-#         "mau",
-#         "engagement",
-#         "dau_active",
-#         "wau_active",
-#         "mau_active",
-#         "engagement_active",
-#     }
-
-#     # Test that running engagements again doesn't error if there's no new data
-#     stats.engagement()
+    assert np.all(stickiness.dau == dau)
+    assert np.all(stickiness.wau == wau)
+    assert np.all(stickiness.mau == mau)
+    assert np.all(stickiness.engagement == engagement)
+    assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
 
 
-# def test_engagement_too_many_min_sessions(pawprint_default_statistics_tracker):
-#     tracker = pawprint_default_statistics_tracker
-#     stats = pawprint.Statistics(tracker)
-#     stats.sessions()
+def test_engagement_min_sessions(pawprint_default_statistics_tracker):
 
-#     # Test with too large a minimum sessions parameter
-#     stats.engagement(min_sessions=20)
-#     stickiness = stats["engagement"].read()
-#     assert len(stickiness) == 2
-#     assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
+    tracker = pawprint_default_statistics_tracker
+    stats = pawprint.Statistics(tracker)
+    stats.sessions()
+
+    # Now test with a minimum number of sessions
+    stats.engagement(min_sessions=2)
+    stickiness = stats["engagement"].read()
+
+    # Ground truth
+    active = np.array([1, 1])
+    engagement_active = np.array([1, 1])
+    dau = np.array([2, 1])
+
+    assert np.all(stickiness.dau_active == active)
+    assert np.all(stickiness.wau_active == active)
+    assert np.all(stickiness.mau_active == active)
+    assert np.all(stickiness.dau == dau)
+    assert np.all(stickiness.engagement_active == engagement_active)
+    assert set(stickiness.columns) == {
+        "timestamp",
+        "dau",
+        "wau",
+        "mau",
+        "engagement",
+        "dau_active",
+        "wau_active",
+        "mau_active",
+        "engagement_active",
+    }
+
+    # Test that running engagements again doesn't error if there's no new data
+    stats.engagement()
 
 
-# def test_engagement_append_mode(pawprint_default_statistics_tracker):
-#     tracker = pawprint_default_statistics_tracker
-#     stats = pawprint.Statistics(tracker)
-#     stats.sessions()
+def test_engagement_too_many_min_sessions(pawprint_default_statistics_tracker):
+    tracker = pawprint_default_statistics_tracker
+    stats = pawprint.Statistics(tracker)
+    stats.sessions()
 
-#     stats.engagement(min_sessions=20)
+    # Test with too large a minimum sessions parameter
+    stats.engagement(min_sessions=20)
+    stickiness = stats["engagement"].read()
+    assert len(stickiness) == 2
+    assert set(stickiness.columns) == {"timestamp", "dau", "wau", "mau", "engagement"}
 
-#     # Try again with append-only
-#     stats.engagement(clean=False)
-#     stickiness = stats["engagement"].read()
-#     assert len(stickiness.columns) == 5
-#     assert len(stickiness) == 2
 
-#     stats.engagement(clean=True, min_sessions=2)
-#     stickiness = stats["engagement"].read()
-#     assert len(stickiness) == 2
-#     assert len(stickiness.columns) == 9
+def test_engagement_append_mode(pawprint_default_statistics_tracker):
+    tracker = pawprint_default_statistics_tracker
+    stats = pawprint.Statistics(tracker)
+    stats.sessions()
+
+    stats.engagement(min_sessions=20)
+
+    # Try again with append-only
+    stats.engagement(clean=False)
+    stickiness = stats["engagement"].read()
+    assert len(stickiness.columns) == 5
+    assert len(stickiness) == 2
+
+    stats.engagement(clean=True, min_sessions=2)
+    stickiness = stats["engagement"].read()
+    assert len(stickiness) == 2
+    assert len(stickiness.columns) == 9


### PR DESCRIPTION
This PR refactors the `sessions` calculations to allow for events to be processed in batches. This should help save memory. 

In order to implement the batching, `sessions.py` needed some small changes. 
- `Sessions.closed_sessions` now gets reset to an empty list whenever the `Sessions.write_to_db()` method is called. This avoids re-writing sessions that have already been written.
- `Sessions.current_sessions` now gets reset to an empty dictionary whenever the `Sessions.close_open_sessions()` method is called. This was not strictly necessary for the new batching to work, but seems like the expected behavior.

This PR also includes some new tests that use the `batch_size` parameter.