### PR TITLE
Fix duplicate sessions

### DIFF
--- a/pawprint/sessions.py
+++ b/pawprint/sessions.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 class UserCurrentSession:
     """
-    One user's current session. This stores the start and end of the 
+    One user's current session. This stores the start and end of the
     session, the number of events in the session, and the name of the event.
     """
 
@@ -32,7 +32,7 @@ class UserCurrentSession:
         """
 
         # If the event is within the session
-        if (event_timestamp - self.last_timestamp).seconds < duration * 60:
+        if (event_timestamp - self.last_timestamp).total_seconds() < duration * 60:
 
             # Update the current session's last event time
             # and add the event to the list of events
@@ -56,7 +56,7 @@ class UserCurrentSession:
     def close_session(self):
         """
         The current session has come to a close when we received an event
-        outside of the max inter-event duration. As such, construct a 
+        outside of the max inter-event duration. As such, construct a
         payload that contains information about this session, for later storage.
         """
         return {
@@ -97,9 +97,7 @@ class Sessions:
 
         # Otherwise, log the event to their existing session
         else:
-            log_output = self.current_sessions[user_id].log_event(
-                timestamp, events, duration
-            )
+            log_output = self.current_sessions[user_id].log_event(timestamp, events, duration)
 
             # If they had a previous session, this event may be far enough in time from
             # the last event to close that previous session. If so, take the last

--- a/pawprint/statistics.py
+++ b/pawprint/statistics.py
@@ -32,12 +32,12 @@ class Statistics(object):
         # If we're starting clean, drop the database table containint existing sessions
         if clean:
             stats.drop_table()
-            self.tracker.logger.info("Dropped existing sessions table")
+            self.tracker.logger.info("pawprint: Dropped existing sessions table")
 
         # This try statement contains a few SQL queries; if any of them fail with a
         # ProgrammingError, the try is exited and the sessions will be rebuilt from scratch.
         try:
-            self.tracker.logger.info("Checking if there are new events since last session")
+            self.tracker.logger.info("pawprint: Checking if there are new events since last session")
 
             # Try to get the time of the very last event stored in the database
             # If the query fails, sessions will be built from scratch
@@ -48,7 +48,7 @@ class Statistics(object):
                 self.tracker.db,
             ).loc[0, "last_timestamp"]
 
-            self.tracker.logger.info("Last entry set to {}".format(last_entry))
+            self.tracker.logger.info("pawprint: Last entry set to {}".format(last_entry))
 
             # All events after this time are new to us, so construct the query
             # to get the list of unique users since this last event
@@ -64,7 +64,7 @@ class Statistics(object):
 
             # If there are no users, exit because there's nothing to update
             if len(unique_users) == 0:
-                self.tracker.logger.info("No users since last_entry. Exiting")
+                self.tracker.logger.info("pawprint: No users since last_entry. Exiting")
                 return
 
             # Construct a PostgreSQL-friendly string representing the list of unique users
@@ -105,7 +105,7 @@ class Statistics(object):
 
             # Delete the last recorded sessions from the sessions table
             try:
-                self.tracker.logger.info("Attempting to remove users' last sessions from DB table.")
+                self.tracker.logger.info("pawprint: Attempting to remove users' last sessions from DB table.")
 
                 for user, time in rows_to_delete:
                     time = pd.Timestamp(time)
@@ -117,7 +117,7 @@ class Statistics(object):
                         time,
                     )
                     pd.io.sql.execute(delete_session_query, con=self.tracker.db)
-                self.tracker.logger.info("Users' last session removed from sessions DB table.")
+                self.tracker.logger.info("pawprint: Users' last session removed from sessions DB table.")
             except ProgrammingError:
                 raise
 
@@ -159,11 +159,11 @@ class Statistics(object):
             # Write all (sorted) closed sessions to database
             # This resets `open_sessions.closed_sessions` to empty list
             # and leaves `open_sessions.current_sessions` as-is for next run through loop
-            self.tracker.logger.info("Batch {}: writing events".format(batch_number))
+            self.tracker.logger.info("pawprint: Batch {}: writing events".format(batch_number))
             open_sessions.write_to_db(
                 table=stats.table, db=self.tracker.db, if_exists="append", index=False
             )
-            self.tracker.logger.info("Batch {}: events written to DB".format(batch_number))
+            self.tracker.logger.info("pawprint: Batch {}: events written to DB".format(batch_number))
 
             # Grab the next batch of events from the database
             batch_number += 1
@@ -179,14 +179,14 @@ class Statistics(object):
                 params=params,
             )
 
-        self.tracker.logger.info("Event logging loop exited")
+        self.tracker.logger.info("pawprint: Event logging loop exited")
         # Close and write any leftover open sessions
         open_sessions.close_open_sessions()
-        self.tracker.logger.info("Closed all remaining open sessions")
+        self.tracker.logger.info("pawprint: Closed all remaining open sessions")
         open_sessions.write_to_db(
             table=stats.table, db=self.tracker.db, if_exists="append", index=False
         )
-        self.tracker.logger.info("Remaining sessions written to DB")
+        self.tracker.logger.info("pawprint: Remaining sessions written to DB")
 
     def engagement(self, clean=False, start=None, min_sessions=3):
         """Calculates the daily and monthly average users, and the stickiness as the ratio."""

--- a/pawprint/statistics.py
+++ b/pawprint/statistics.py
@@ -18,9 +18,7 @@ class Statistics(object):
         """
         Overload the [] operator. This is used to access the various statistics tables.
         """
-        return Tracker(
-            db=self.tracker.db, table="{}__{}".format(self.tracker.table, tracker)
-        )
+        return Tracker(db=self.tracker.db, table="{}__{}".format(self.tracker.table, tracker))
 
     def sessions(self, duration=30, clean=False, batch_size=100000):
         """Create a table of user sessions."""
@@ -34,10 +32,13 @@ class Statistics(object):
         # If we're starting clean, drop the database table containint existing sessions
         if clean:
             stats.drop_table()
+            self.tracker.logger.info("Dropped existing sessions table")
 
         # This try statement contains a few SQL queries; if any of them fail with a
         # ProgrammingError, the try is exited and the sessions will be rebuilt from scratch.
         try:
+            self.tracker.logger.info("Checking if there are new events since last session")
+
             # Try to get the time of the very last event stored in the database
             # If the query fails, sessions will be built from scratch
             last_entry = pd.read_sql(
@@ -47,12 +48,12 @@ class Statistics(object):
                 self.tracker.db,
             ).loc[0, "last_timestamp"]
 
+            self.tracker.logger.info("Last entry set to {}".format(last_entry))
+
             # All events after this time are new to us, so construct the query
             # to get the list of unique users since this last event
             user_query = "SELECT DISTINCT({}) FROM {} WHERE {} > %(last_entry)s".format(
-                self.tracker.user_field,
-                self.tracker.table,
-                self.tracker.timestamp_field,
+                self.tracker.user_field, self.tracker.table, self.tracker.timestamp_field,
             )
             params = {"last_entry": str(last_entry)}
 
@@ -63,12 +64,11 @@ class Statistics(object):
 
             # If there are no users, exit because there's nothing to update
             if len(unique_users) == 0:
+                self.tracker.logger.info("No users since last_entry. Exiting")
                 return
 
             # Construct a PostgreSQL-friendly string representing the list of unique users
-            unique_user_str = (
-                "('" + "','".join([str(user) for user in unique_users]) + "')"
-            )
+            unique_user_str = "('" + "','".join([str(user) for user in unique_users]) + "')"
 
             # Grab the last recorded session for each user in unique users
             last_sessions = pd.read_sql(
@@ -80,6 +80,12 @@ class Statistics(object):
                     self.tracker.user_field,
                 ),
                 self.tracker.db,
+            )
+
+            self.tracker.logger.info(
+                "{} existing sessions found. Reopening for possible updating...".format(
+                    last_sessions.shape[0]
+                )
             )
 
             # Create UserCurrentSession() from last session of each unique user
@@ -95,12 +101,12 @@ class Statistics(object):
             # We've fully reconstructed the last session of each user, so handle the case
             # where the user's session was not finished when we last built Sessions
             # Now we need to delete those sessions from the database so we don't double-count
-            rows_to_delete = zip(
-                last_sessions["user_id"].values, last_sessions["timestamp"].values
-            )
+            rows_to_delete = zip(last_sessions["user_id"].values, last_sessions["timestamp"].values)
 
             # Delete the last recorded sessions from the sessions table
             try:
+                self.tracker.logger.info("Attempting to remove users' last sessions from DB table.")
+
                 for user, time in rows_to_delete:
                     time = pd.Timestamp(time)
                     delete_session_query = "DELETE FROM {} WHERE {} = '{}' AND {} = '{}'".format(
@@ -111,10 +117,14 @@ class Statistics(object):
                         time,
                     )
                     pd.io.sql.execute(delete_session_query, con=self.tracker.db)
+                self.tracker.logger.info("Users' last session removed from sessions DB table.")
             except ProgrammingError:
                 raise
 
         except ProgrammingError:  # raised when some query above fails; triggers full session rebuild
+            self.tracker.logger.info(
+                "Setting last_entry to 1900-01-01 to trigger sessions from scratch"
+            )
             last_entry = datetime(1900, 1, 1)
             params = {"last_entry": str(last_entry)}
 
@@ -122,8 +132,9 @@ class Statistics(object):
         # We can now read all events since the last recorded event and construct sessions
         # Let's grab the first batch of new events from the events table
         batch_number = 0
-        events_query = "SELECT * FROM {} WHERE {} > %(last_entry)s LIMIT {} OFFSET {}".format(
+        events_query = "SELECT * FROM {} WHERE {} > %(last_entry)s ORDER BY {} ASC LIMIT {} OFFSET {}".format(
             self.tracker.table,
+            self.tracker.timestamp_field,
             self.tracker.timestamp_field,
             batch_size,
             batch_size * batch_number,
@@ -132,9 +143,9 @@ class Statistics(object):
 
         # While there are events, read them in batches and add them to user session data
         while events.shape[0] > 0:
-
-            print("batch: ", batch_number)
-            print("num events in batch: ", events.shape[0])
+            self.tracker.logger.info(
+                "Batch {}: logging {} events".format(batch_number, events.shape[0])
+            )
 
             # Process events that we have read
             for _, event_row in events.iterrows():  # loop through events
@@ -148,15 +159,18 @@ class Statistics(object):
             # Write all (sorted) closed sessions to database
             # This resets `open_sessions.closed_sessions` to empty list
             # and leaves `open_sessions.current_sessions` as-is for next run through loop
+            self.tracker.logger.info("Batch {}: writing events".format(batch_number))
             open_sessions.write_to_db(
                 table=stats.table, db=self.tracker.db, if_exists="append", index=False
             )
+            self.tracker.logger.info("Batch {}: events written to DB".format(batch_number))
 
             # Grab the next batch of events from the database
             batch_number += 1
             events = pd.read_sql(
-                "SELECT * FROM {} WHERE {} > %(last_entry)s LIMIT {} OFFSET {}".format(
+                "SELECT * FROM {} WHERE {} > %(last_entry)s ORDER BY {} ASC LIMIT {} OFFSET {}".format(
                     self.tracker.table,
+                    self.tracker.timestamp_field,
                     self.tracker.timestamp_field,
                     batch_size,
                     batch_size * batch_number,
@@ -165,11 +179,14 @@ class Statistics(object):
                 params=params,
             )
 
+        self.tracker.logger.info("Event logging loop exited")
         # Close and write any leftover open sessions
         open_sessions.close_open_sessions()
+        self.tracker.logger.info("Closed all remaining open sessions")
         open_sessions.write_to_db(
             table=stats.table, db=self.tracker.db, if_exists="append", index=False
         )
+        self.tracker.logger.info("Remaining sessions written to DB")
 
     def engagement(self, clean=False, start=None, min_sessions=3):
         """Calculates the daily and monthly average users, and the stickiness as the ratio."""
@@ -184,9 +201,7 @@ class Statistics(object):
         # Determine whether the stats table exists and contains data, or if we should create one
         try:  # if this passes, the table exists and may contain data
             last_entry = pd.read_sql(
-                "SELECT timestamp FROM {} ORDER BY timestamp DESC LIMIT 1".format(
-                    stats.table
-                ),
+                "SELECT timestamp FROM {} ORDER BY timestamp DESC LIMIT 1".format(stats.table),
                 self.tracker.db,
             ).loc[0, "timestamp"]
         except ProgrammingError:  # otherwise, the table doesn't exist
@@ -202,14 +217,10 @@ class Statistics(object):
         # If we're also calculating by imposing a minimum number of events per user
         if min_sessions:
             # Count the number of rows per user in the sessions table
-            session_counts = (
-                self["sessions"].read().groupby(self.tracker.user_field).count()
-            )
+            session_counts = self["sessions"].read().groupby(self.tracker.user_field).count()
 
             # Select the active users where there are at least min_sessions rows per user
-            active_users = session_counts[
-                session_counts["duration"] >= min_sessions
-            ].index
+            active_users = session_counts[session_counts["duration"] >= min_sessions].index
             active_users = [str(user) for user in active_users]
 
             # If there are no users that qualify, turn off min_sessions calculations
@@ -222,18 +233,14 @@ class Statistics(object):
         )
         if not len(stickiness):  # if this has been run too recently, do nothing
             return
-        stickiness.rename(
-            columns={"count": "dau", "datetime": "timestamp"}, inplace=True
-        )
+        stickiness.rename(columns={"count": "dau", "datetime": "timestamp"}, inplace=True)
         stickiness.index = pd.to_datetime(stickiness["timestamp"])
         stickiness.drop("timestamp", axis=1, inplace=True)
         stickiness = stickiness.resample("D").sum().fillna(0).astype(int)
 
         # Calculate DAU for active users if requested
         if min_sessions:
-            active_users_query = {
-                "{}__in".format(self.tracker.user_field): list(active_users)
-            }
+            active_users_query = {"{}__in".format(self.tracker.user_field): list(active_users)}
             active_dau = self["sessions"].count(
                 "DISTINCT({})".format(self.tracker.user_field),
                 timestamp__gt=start,
@@ -304,9 +311,7 @@ class Statistics(object):
         # Calculate engagement as DAU / MAU
         stickiness["engagement"] = stickiness.dau / stickiness.mau
         if min_sessions:
-            stickiness["engagement_active"] = (
-                stickiness.dau_active / stickiness.mau_active
-            )
+            stickiness["engagement_active"] = stickiness.dau_active / stickiness.mau_active
 
         # Active user counts should be ints
         stickiness.wau = stickiness.wau.astype(int)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pawprint",
-    version="2.1.0",
+    version="2.1.1",
     description="A flexible event tracker for rapid analysis.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -79,7 +79,7 @@ def test_instantiate_tracker_from_dot_file(drop_tracker_test_table):
     # Ensure all the entries are as they should be
     assert tracker.db == "postgresql:///little_bean_toes"
     assert tracker.table is None
-    assert tracker.logger is None
+    # assert tracker.logger is None
     assert tracker.json_field == "boop"  # field present in dotfile but overwritten in init
 
     os.remove(".pawprint")
@@ -424,7 +424,7 @@ def test_nonsilent_write_errors(error_logger):
         print(logs[3])
 
     assert len(logs) == 6
-    assert logs[0].startswith("pawprint failed to write.")
+    assert logs[0].startswith("pawprint: pawprint failed to write.")
     assert "Table: None. Query: INSERT INTO None () VALUES ();" in logs[0]
     assert "Query: INSERT INTO None (event) VALUES ('going_to_fail')" in logs[3]
 


### PR DESCRIPTION
Fixes two critical problems:
1. Queries for events need an ORDER BY to ensure they are pulled in chronological order
2. When checking if the time between events is greater than the specified window, we need to use `.total_seconds()` not, as previously `.seconds` to get the desired behavior. `.seconds` was ignoring dates.